### PR TITLE
Régler (Issue #5): les étiquettes de boutons

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -20,7 +20,7 @@ Fournit le formulaire de calcul et envoie les données au backend Flask.
 
       <div class="buttons">
          <button type="button" class="btn" onclick="appendToDisplay('1')">1</button>
-         <button type="button" class="btn" onclick="appendToDisplay('2')">02</button>
+         <button type="button" class="btn" onclick="appendToDisplay('2')">2</button>
          <button type="button" class="btn" onclick="appendToDisplay('3')">3</button>
          <button type="button" class="btn operator" onclick="appendToDisplay('+')">+</button>
 
@@ -30,14 +30,14 @@ Fournit le formulaire de calcul et envoie les données au backend Flask.
          <button type="button" class="btn operator" onclick="appendToDisplay('-')">-</button>
 
          <button type="button" class="btn" onclick="appendToDisplay('7')">7</button>
-         <button type="button" class="btn" onclick="appendToDisplay('8')">88</button>
+         <button type="button" class="btn" onclick="appendToDisplay('8')">8</button>
          <button type="button" class="btn" onclick="appendToDisplay('9')">9</button>
-         <button type="button" class="btn operator" onclick="appendToDisplay('*')"></button>
+         <button type="button" class="btn operator" onclick="appendToDisplay('*')">x</button>
 
          <button type="button" class="btn" onclick="appendToDisplay('0')">0</button>
          <button type="button" class="btn" onclick="clearDisplay()">C</button>
          <button type="submit" class="btn operator">=</button>
-         <button type="button" class="btn operator" onclick="appendToDisplay('/')"></button>
+         <button type="button" class="btn operator" onclick="appendToDisplay('/')">÷</button>
       </div>
    </form>
 </div>


### PR DESCRIPTION
correctif(index) : corriger les libellés des boutons numériques et opérateurs

Changement :

- Suppression du '0' superflu dans le bouton '02'

- Suppression du doublon '88'

- Ajout du symbole 'x' pour le bouton de multiplication

- Ajout du symbole '÷' pour le bouton de division

Fichier : templates/index.html

Impact : améliore la cohérence visuelle et fonctionnelle des boutons de la calculatrice.